### PR TITLE
Embassy sync requires critical-section, linking errors occur without it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ default = ["std", "alloc", "esp-idf-sys"]
 std = ["alloc", "esp-idf-sys/std", "edge-executor?/std"]
 alloc = []
 riscv-ulp-hal = []
+embassy-sync = [ "dep:embassy-sync", "critical-section" ]
+critical-section = [ "dep:critical-section" ]
 
 [dependencies]
 nb = "1.0.0"


### PR DESCRIPTION
Without this, attempts to use embassy-sync/embassy-time will fail with linker errors because critical section support is missing
